### PR TITLE
✨ Drag & Drop Sorting Board 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,6 +200,12 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/app/sorting/additional/page.tsx
+++ b/src/app/sorting/additional/page.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useTodaySortedTasks } from '@/entities/task/model/selector'
-import { TaskStatus } from '@/entities/task/model/types'
+import { useUnsortedTodayTasks } from '@/entities/task/model/selector'
 import { SortingBoard } from '@/widgets/sorting-board/ui/sorting-board'
 
 export default function AdditionalPage() {
-  const todayUnassignedTasks = useTodaySortedTasks(TaskStatus.Unassigned)
+  const todayUnassignedTasks = useUnsortedTodayTasks()
   return <SortingBoard tasks={todayUnassignedTasks} />
 }

--- a/src/app/sorting/additional/page.tsx
+++ b/src/app/sorting/additional/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { useTodaySortedTasks } from '@/entities/task/model/selector'
+import { TaskStatus } from '@/entities/task/model/types'
+import { SortingBoard } from '@/widgets/sorting-board/ui/sorting-board'
+
+export default function AdditionalPage() {
+  const todayUnassignedTasks = useTodaySortedTasks(TaskStatus.Unassigned)
+  return <SortingBoard tasks={todayUnassignedTasks} />
+}

--- a/src/app/sorting/layout.tsx
+++ b/src/app/sorting/layout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { SortingProvider } from '@/features/task/sort/ui/sorting-provider'
 import { Header } from '@/shared/ui/header'
 
 function SortingHeader() {
@@ -23,7 +24,9 @@ export default function SortingLayout({
   return (
     <>
       <SortingHeader />
-      {children}
+      <SortingProvider>
+        <div className="relative h-[calc(100dvh-3rem)] mt-12">{children}</div>
+      </SortingProvider>
     </>
   )
 }

--- a/src/app/sorting/page.tsx
+++ b/src/app/sorting/page.tsx
@@ -1,6 +1,9 @@
 'use client'
+
+import { useUnsortedTasks } from '@/entities/task/model/selector'
 import { SortingBoard } from '@/widgets/sorting-board/ui/sorting-board'
 
 export default function SortingPage() {
-  return <SortingBoard />
+  const unsortedTasks = useUnsortedTasks()
+  return <SortingBoard tasks={unsortedTasks} />
 }

--- a/src/app/sorting/page.tsx
+++ b/src/app/sorting/page.tsx
@@ -1,5 +1,6 @@
 'use client'
+import { SortingBoard } from '@/widgets/sorting-board/ui/sorting-board'
 
 export default function SortingPage() {
-  return <h1>SortingPage</h1>
+  return <SortingBoard />
 }

--- a/src/app/unsorted/layout.tsx
+++ b/src/app/unsorted/layout.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
+import { useTaskStore } from '@/entities/task/model/slice'
 import {
   UnsortedProvider,
   useUnsorted,
@@ -10,8 +11,29 @@ import { EditActions } from '@/features/task/organize/ui/edit-actions'
 import { ButtonGhost } from '@/shared/ui/button'
 import { Header } from '@/shared/ui/header'
 
+// TODO: 로직 분리
 function UnsortedHeader() {
   const { isEditMode, toggleEditMode } = useUnsorted()
+  const router = useRouter()
+
+  const sortingStatus = useTaskStore((state) => state.sortingStatus)
+  const setSortingStatus = useTaskStore((state) => state.setSortingStatus)
+
+  const handleSortClick = () => {
+    const route = sortingStatus.includes('ADDITIONAL')
+      ? '/sorting/additional'
+      : '/sorting'
+
+    if (sortingStatus === 'UNSORTED') {
+      setSortingStatus('SORTING')
+    }
+    if (sortingStatus === 'ADDITIONAL') {
+      setSortingStatus('ADDITIONAL_SORTING')
+    }
+
+    router.push(route)
+  }
+
   return (
     <Header>
       <Header.Left>
@@ -23,8 +45,11 @@ function UnsortedHeader() {
             <EditActions />
           ) : (
             <>
-              <ButtonGhost>
-                <Link href="/sorting">Sort</Link>
+              <ButtonGhost
+                onClick={handleSortClick}
+                disabled={sortingStatus === 'SORTED'}
+              >
+                Sort
               </ButtonGhost>
               <ButtonGhost onClick={toggleEditMode}>Organize</ButtonGhost>
             </>

--- a/src/entities/task/model/selector.ts
+++ b/src/entities/task/model/selector.ts
@@ -43,10 +43,13 @@ export const useUnsortedTasks = (): Task[] => {
  * (컴포넌트 내 훅)
  * @returns {Task[]} 오늘 할 일 중 분류되지 않은 태스크 목록
  */
-export const useUnsortedTodayTasks = (): Task[] =>
-  useTaskStore((state) =>
-    state.tasks.filter((task) => isUnsorted(task) && isTodayTask(task)),
-  )
+export const useUnsortedTodayTasks = (): Task[] => {
+  const tasks = useTaskStore((state) => state.tasks)
+
+  return useMemo(() => {
+    return tasks.filter((task) => isUnsorted(task) && isTodayTask(task))
+  }, [tasks])
+}
 
 /**
  * 오늘 날짜이며 특정 상태에 해당하는 분류된 태스크 목록을 구독 및 반환

--- a/src/entities/task/model/slice.ts
+++ b/src/entities/task/model/slice.ts
@@ -38,6 +38,7 @@ export const useTaskStore = create<TaskStore>()(
             set(
               (state) => ({
                 tasks: [
+                  ...state.tasks,
                   {
                     id: nanoid(),
                     content,
@@ -46,7 +47,6 @@ export const useTaskStore = create<TaskStore>()(
                     postponedCount: 0,
                     updatedAt: getCurrentDate(),
                   },
-                  ...state.tasks,
                 ],
               }),
               false,
@@ -83,6 +83,7 @@ export const useTaskStore = create<TaskStore>()(
             updateTaskById(
               id,
               (task) => ({
+                status: TaskStatus.Postponed,
                 postponedCount: task.postponedCount + 1,
               }),
               'postponeTask',
@@ -117,14 +118,14 @@ export const useTaskStore = create<TaskStore>()(
 
           resetUnfinishedTasks: () => {
             const now = getCurrentDate()
-
             set(
               (state) => ({
                 sortingStatus: 'UNSORTED',
                 tasks: state.tasks.map((task) => {
                   if (
-                    !task.completedAt &&
-                    task.status !== TaskStatus.Unassigned
+                    (!task.completedAt &&
+                      task.status !== TaskStatus.Unassigned) ||
+                    task.status === TaskStatus.Postponed
                   ) {
                     return {
                       ...task,

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -23,8 +23,13 @@ export interface Task {
   completedAt?: Date
 }
 
-export type SortingStatus = 'UNSORTED' | 'SORTING' | 'SORTED'
-
+export type SortingStatus =
+  | 'UNSORTED' // 분류 전
+  | 'SORTING' // 분류 중
+  | 'SORTED' // 분류 후
+  | 'ADDITIONAL' // 추가 분류 전
+  | 'ADDITIONAL_SORTING' // 추가 분류 중
+  
 interface TaskState {
   tasks: Task[]
   sortingStatus: SortingStatus

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -4,6 +4,7 @@ export enum TaskStatus {
   UrgentNotImportant = 'urgent-not-important',
   NotUrgentImportant = 'not-urgent-important',
   NotUrgentNotImportant = 'not-urgent-not-important',
+  Postponed = 'postponed',
 }
 
 export interface Task {
@@ -28,6 +29,7 @@ interface TaskState {
   tasks: Task[]
   sortingStatus: SortingStatus
 }
+
 interface TaskActions {
   addTask: (content: string, isToday?: boolean) => void
   updateTask: (taskId: string, content: string) => void

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -7,6 +7,11 @@ export enum TaskStatus {
   Postponed = 'postponed',
 }
 
+export type MatrixTaskStatus = Exclude<
+  TaskStatus,
+  TaskStatus.Unassigned | TaskStatus.Postponed
+>
+
 export interface Task {
   // UUID
   id: string
@@ -29,7 +34,7 @@ export type SortingStatus =
   | 'SORTED' // 분류 후
   | 'ADDITIONAL' // 추가 분류 전
   | 'ADDITIONAL_SORTING' // 추가 분류 중
-  
+
 interface TaskState {
   tasks: Task[]
   sortingStatus: SortingStatus

--- a/src/features/task/add/model/use-add-task.ts
+++ b/src/features/task/add/model/use-add-task.ts
@@ -1,0 +1,15 @@
+import { useTaskStore } from '@/entities/task/model/slice'
+
+export const useAddTask = () => {
+  const addTask = useTaskStore((state) => state.addTask)
+  const setSortingStatus = useTaskStore((state) => state.setSortingStatus)
+  const sortingStatus = useTaskStore((state) => state.sortingStatus)
+
+  return (content: string, isToday = false) => {
+    addTask(content, isToday)
+
+    if (isToday && sortingStatus === 'SORTED') {
+      setSortingStatus('ADDITIONAL')
+    }
+  }
+}

--- a/src/features/task/add/ui/add-task-container.tsx
+++ b/src/features/task/add/ui/add-task-container.tsx
@@ -67,7 +67,9 @@ export function AddTaskContainer() {
         }}
       >
         <AddTaskForm
-          isTodayActive={sortingStatus === 'SORTED'}
+          isTodayActive={
+            sortingStatus !== 'UNSORTED' && sortingStatus !== 'SORTING'
+          }
           showOverlay={showOverlay}
           onFocus={handleFocus}
         />

--- a/src/features/task/add/ui/add-task-form.tsx
+++ b/src/features/task/add/ui/add-task-form.tsx
@@ -1,14 +1,12 @@
 'use client'
 
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { DevTool } from '@hookform/devtools'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useRef } from 'react'
 import { Controller, FieldErrors, useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-import { useTaskStore } from '@/entities/task/model/slice'
+import { useAddTask } from '@/features/task/add/model/use-add-task'
 import { AddTaskFormSchema } from '@/features/task/lib/schema'
 import { CONTENT_MAX_LENGTH } from '@/shared/consts/form'
 import { ADD_TOAST, FORM_TOAST } from '@/shared/consts/toast-config'
@@ -30,7 +28,7 @@ export const AddTaskForm = ({
   showOverlay,
   onFocus,
 }: AddTaskFormProps) => {
-  const addTask = useTaskStore((state) => state.addTask)
+  const addTask = useAddTask()
   const {
     control,
     reset,

--- a/src/features/task/sort/ui/consts.ts
+++ b/src/features/task/sort/ui/consts.ts
@@ -1,0 +1,33 @@
+import { Clock, Send, Star, Zap } from 'lucide-react'
+
+import { MatrixTaskStatus, TaskStatus } from '@/entities/task/model/types'
+
+export const CARD_DECK_OFFSETS = [
+  'translate-y-[-50%] z-50',
+  'translate-y-[calc(-50%-5px)] z-40',
+  'translate-y-[calc(-50%-10px)] z-30',
+  'translate-y-[calc(-50%-15px)] z-20',
+  'translate-y-[calc(-50%-20px)] z-10',
+] as const
+
+export const MATRIX_CONFIG: Record<
+  MatrixTaskStatus,
+  { label: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  [TaskStatus.UrgentImportant]: {
+    label: 'Do Now!',
+    icon: Zap,
+  },
+  [TaskStatus.UrgentNotImportant]: {
+    label: 'Delegable',
+    icon: Send,
+  },
+  [TaskStatus.NotUrgentImportant]: {
+    label: 'Schedule',
+    icon: Star,
+  },
+  [TaskStatus.NotUrgentNotImportant]: {
+    label: 'Later',
+    icon: Clock,
+  },
+}

--- a/src/features/task/sort/ui/drop-zone.tsx
+++ b/src/features/task/sort/ui/drop-zone.tsx
@@ -1,0 +1,74 @@
+import { useDroppable } from '@dnd-kit/core'
+import { cva } from 'class-variance-authority'
+import { Clock, Send, Star, Zap } from 'lucide-react'
+
+import { TaskStatus } from '@/entities/task/model/types'
+import { cn } from '@/shared/lib/utils'
+
+interface DropZoneProps {
+  status: Exclude<TaskStatus, TaskStatus.Unassigned>
+}
+
+const dropZoneVariants = cva('border-none text-sm font-semibold', {
+  variants: {
+    status: {
+      [TaskStatus.UrgentImportant]: 'bg-quadrant-red text-icon-do',
+      [TaskStatus.UrgentNotImportant]: 'bg-quadrant-green text-icon-delegable',
+      [TaskStatus.NotUrgentImportant]: 'bg-quadrant-yellow text-icon-schedule',
+      [TaskStatus.NotUrgentNotImportant]: 'bg-quadrant-blue text-icon-later',
+    },
+    defaultVariants: {
+      status: TaskStatus.UrgentImportant,
+    },
+  },
+})
+
+const matrixTypo: Record<TaskStatus, string> = {
+  [TaskStatus.UrgentImportant]: 'Do Now!',
+  [TaskStatus.UrgentNotImportant]: 'Delegable',
+  [TaskStatus.NotUrgentImportant]: 'Schedule',
+  [TaskStatus.NotUrgentNotImportant]: 'Later',
+}
+
+export function DropZone({ status }: DropZoneProps) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: status,
+  })
+
+  const style = {
+    filter: isOver
+      ? `drop-shadow(0 0 2px var(--background))
+                      drop-shadow(0 0 4px var(--background))
+                      drop-shadow(0 0 8px var(--background))`
+      : undefined,
+    boxShadow: isOver
+      ? `inset 0 0 2px var(--background),
+      inset 0 0 4px var(--background),
+      inset 0 0 8px var(--background)`
+      : undefined,
+  }
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        dropZoneVariants({ status }),
+        'flex items-center justify-center',
+      )}
+    >
+      <div className="flex flex-col items-center justify-center gap-0.5">
+        {status === TaskStatus.UrgentImportant && <Zap className="w-6 h-6" />}
+        {status === TaskStatus.UrgentNotImportant && (
+          <Send className="w-6 h-6" />
+        )}
+        {status === TaskStatus.NotUrgentImportant && (
+          <Star className="w-6 h-6" />
+        )}
+        {status === TaskStatus.NotUrgentNotImportant && (
+          <Clock className="w-6 h-6" />
+        )}
+        {matrixTypo[status]}
+      </div>
+    </div>
+  )
+}

--- a/src/features/task/sort/ui/drop-zone.tsx
+++ b/src/features/task/sort/ui/drop-zone.tsx
@@ -6,7 +6,7 @@ import { TaskStatus } from '@/entities/task/model/types'
 import { cn } from '@/shared/lib/utils'
 
 interface DropZoneProps {
-  status: Exclude<TaskStatus, TaskStatus.Unassigned>
+  status: Exclude<TaskStatus, TaskStatus.Unassigned | TaskStatus.Postponed>
 }
 
 const dropZoneVariants = cva('border-none text-sm font-semibold', {

--- a/src/features/task/sort/ui/drop-zone.tsx
+++ b/src/features/task/sort/ui/drop-zone.tsx
@@ -1,73 +1,57 @@
 import { useDroppable } from '@dnd-kit/core'
 import { cva } from 'class-variance-authority'
-import { Clock, Send, Star, Zap } from 'lucide-react'
 
-import { TaskStatus } from '@/entities/task/model/types'
+import { MatrixTaskStatus, TaskStatus } from '@/entities/task/model/types'
+import { MATRIX_CONFIG } from '@/features/task/sort/ui/consts'
 import { cn } from '@/shared/lib/utils'
 
 interface DropZoneProps {
-  status: Exclude<TaskStatus, TaskStatus.Unassigned | TaskStatus.Postponed>
+  status: MatrixTaskStatus
 }
 
-const dropZoneVariants = cva('border-none text-sm font-semibold', {
-  variants: {
-    status: {
-      [TaskStatus.UrgentImportant]: 'bg-quadrant-red text-icon-do',
-      [TaskStatus.UrgentNotImportant]: 'bg-quadrant-green text-icon-delegable',
-      [TaskStatus.NotUrgentImportant]: 'bg-quadrant-yellow text-icon-schedule',
-      [TaskStatus.NotUrgentNotImportant]: 'bg-quadrant-blue text-icon-later',
-    },
-    defaultVariants: {
-      status: TaskStatus.UrgentImportant,
+const dropZoneVariants = cva(
+  'flex items-center justify-center border-none text-sm font-semibold',
+  {
+    variants: {
+      status: {
+        [TaskStatus.UrgentImportant]: 'bg-quadrant-red text-icon-do',
+        [TaskStatus.UrgentNotImportant]:
+          'bg-quadrant-green text-icon-delegable',
+        [TaskStatus.NotUrgentImportant]:
+          'bg-quadrant-yellow text-icon-schedule',
+        [TaskStatus.NotUrgentNotImportant]: 'bg-quadrant-blue text-icon-later',
+      },
+      isOver: {
+        true: [
+          'drop-shadow-[0_0_2px_var(--background)]',
+          'drop-shadow-[0_0_4px_var(--background)]',
+          'drop-shadow-[0_0_8px_var(--background)]',
+          'shadow-[inset_0_0_2px_var(--background)]',
+          'shadow-[inset_0_0_4px_var(--background)]',
+          'shadow-[inset_0_0_8px_var(--background)]',
+        ].join(' '),
+      },
+
+      defaultVariants: {
+        status: TaskStatus.UrgentImportant,
+        isOver: false,
+      },
     },
   },
-})
-
-const matrixTypo: Record<TaskStatus, string> = {
-  [TaskStatus.UrgentImportant]: 'Do Now!',
-  [TaskStatus.UrgentNotImportant]: 'Delegable',
-  [TaskStatus.NotUrgentImportant]: 'Schedule',
-  [TaskStatus.NotUrgentNotImportant]: 'Later',
-}
+)
 
 export function DropZone({ status }: DropZoneProps) {
   const { isOver, setNodeRef } = useDroppable({
     id: status,
   })
 
-  const style = {
-    filter: isOver
-      ? `drop-shadow(0 0 2px var(--background))
-                      drop-shadow(0 0 4px var(--background))
-                      drop-shadow(0 0 8px var(--background))`
-      : undefined,
-    boxShadow: isOver
-      ? `inset 0 0 2px var(--background),
-      inset 0 0 4px var(--background),
-      inset 0 0 8px var(--background)`
-      : undefined,
-  }
+  const IconComponent = MATRIX_CONFIG[status].icon
+
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(
-        dropZoneVariants({ status }),
-        'flex items-center justify-center',
-      )}
-    >
+    <div ref={setNodeRef} className={cn(dropZoneVariants({ status, isOver }))}>
       <div className="flex flex-col items-center justify-center gap-0.5">
-        {status === TaskStatus.UrgentImportant && <Zap className="w-6 h-6" />}
-        {status === TaskStatus.UrgentNotImportant && (
-          <Send className="w-6 h-6" />
-        )}
-        {status === TaskStatus.NotUrgentImportant && (
-          <Star className="w-6 h-6" />
-        )}
-        {status === TaskStatus.NotUrgentNotImportant && (
-          <Clock className="w-6 h-6" />
-        )}
-        {matrixTypo[status]}
+        <IconComponent className="w-6 h-6" />
+        {MATRIX_CONFIG[status].label}
       </div>
     </div>
   )

--- a/src/features/task/sort/ui/sorting-provider.tsx
+++ b/src/features/task/sort/ui/sorting-provider.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { DndContext, DragEndEvent } from '@dnd-kit/core'
+import { DndContext, DragEndEvent, TouchSensor, useSensor } from '@dnd-kit/core'
 import { restrictToParentElement } from '@dnd-kit/modifiers'
 
 import { useTaskStore } from '@/entities/task/model/slice'
@@ -7,6 +7,13 @@ import { TaskStatus } from '@/entities/task/model/types'
 
 export function SortingProvider({ children }: { children: React.ReactNode }) {
   const sortTask = useTaskStore((state) => state.sortTask)
+
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: {
+      delay: 50,
+      tolerance: 5,
+    },
+  })
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
@@ -20,7 +27,11 @@ export function SortingProvider({ children }: { children: React.ReactNode }) {
     }, 100)
   }
   return (
-    <DndContext onDragEnd={handleDragEnd} modifiers={[restrictToParentElement]}>
+    <DndContext
+      sensors={[touchSensor]}
+      onDragEnd={handleDragEnd}
+      modifiers={[restrictToParentElement]}
+    >
       {children}
     </DndContext>
   )

--- a/src/features/task/sort/ui/sorting-provider.tsx
+++ b/src/features/task/sort/ui/sorting-provider.tsx
@@ -1,5 +1,12 @@
 'use client'
-import { DndContext, DragEndEvent, TouchSensor, useSensor } from '@dnd-kit/core'
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
 import { restrictToParentElement } from '@dnd-kit/modifiers'
 
 import { useTaskStore } from '@/entities/task/model/slice'
@@ -8,12 +15,16 @@ import { TaskStatus } from '@/entities/task/model/types'
 export function SortingProvider({ children }: { children: React.ReactNode }) {
   const sortTask = useTaskStore((state) => state.sortTask)
 
+  const pointerSensor = useSensor(PointerSensor)
+
   const touchSensor = useSensor(TouchSensor, {
     activationConstraint: {
       delay: 50,
       tolerance: 5,
     },
   })
+
+  const sensors = useSensors(pointerSensor, touchSensor)
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event
@@ -26,9 +37,10 @@ export function SortingProvider({ children }: { children: React.ReactNode }) {
       sortTask(active.id as string, over.id as TaskStatus)
     }, 100)
   }
+
   return (
     <DndContext
-      sensors={[touchSensor]}
+      sensors={sensors}
       onDragEnd={handleDragEnd}
       modifiers={[restrictToParentElement]}
     >

--- a/src/features/task/sort/ui/sorting-provider.tsx
+++ b/src/features/task/sort/ui/sorting-provider.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { DndContext, DragEndEvent } from '@dnd-kit/core'
+// import { restrictToParentElement } from '@dnd-kit/modifiers'
+
+import { useTaskStore } from '@/entities/task/model/slice'
+import { TaskStatus } from '@/entities/task/model/types'
+
+export function SortingProvider({ children }: { children: React.ReactNode }) {
+  const sortTask = useTaskStore((state) => state.sortTask)
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+
+    if (!over || !active) {
+      return
+    }
+
+    sortTask(active.id as string, over.id as TaskStatus)
+    // TODO: ative 요소가 사라지는 애니메이션
+    // 이제 저 DOM은 사라져야해
+  }
+  return (
+    <DndContext
+      onDragEnd={handleDragEnd}
+      // modifiers={[restrictToParentElement]}
+    >
+      {children}
+    </DndContext>
+  )
+}

--- a/src/features/task/sort/ui/sorting-provider.tsx
+++ b/src/features/task/sort/ui/sorting-provider.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { DndContext, DragEndEvent } from '@dnd-kit/core'
-// import { restrictToParentElement } from '@dnd-kit/modifiers'
+import { restrictToParentElement } from '@dnd-kit/modifiers'
 
 import { useTaskStore } from '@/entities/task/model/slice'
 import { TaskStatus } from '@/entities/task/model/types'
@@ -20,10 +20,7 @@ export function SortingProvider({ children }: { children: React.ReactNode }) {
     // 이제 저 DOM은 사라져야해
   }
   return (
-    <DndContext
-      onDragEnd={handleDragEnd}
-      // modifiers={[restrictToParentElement]}
-    >
+    <DndContext onDragEnd={handleDragEnd} modifiers={[restrictToParentElement]}>
       {children}
     </DndContext>
   )

--- a/src/features/task/sort/ui/sorting-provider.tsx
+++ b/src/features/task/sort/ui/sorting-provider.tsx
@@ -15,9 +15,9 @@ export function SortingProvider({ children }: { children: React.ReactNode }) {
       return
     }
 
-    sortTask(active.id as string, over.id as TaskStatus)
-    // TODO: ative 요소가 사라지는 애니메이션
-    // 이제 저 DOM은 사라져야해
+    setTimeout(() => {
+      sortTask(active.id as string, over.id as TaskStatus)
+    }, 100)
   }
   return (
     <DndContext onDragEnd={handleDragEnd} modifiers={[restrictToParentElement]}>

--- a/src/features/task/sort/ui/sorting-task-card.tsx
+++ b/src/features/task/sort/ui/sorting-task-card.tsx
@@ -42,7 +42,7 @@ export const SortingTaskCard = ({
       {...listeners}
       {...attributes}
       className={cn(
-        'w-64 text-center',
+        'w-64 text-center font-semibold',
         !isDragging && 'transition-transform duration-200 ease-in-out',
         index > 4 ? offsets[4] : offsets[index],
         className,

--- a/src/features/task/sort/ui/sorting-task-card.tsx
+++ b/src/features/task/sort/ui/sorting-task-card.tsx
@@ -59,7 +59,7 @@ export const SortingTaskCard = ({
       {...listeners}
       {...attributes}
       className={cn(
-        'w-64 text-center font-semibold ',
+        'w-64 text-center font-semibold touch-none',
         index > 4 ? CARD_DECK_OFFSETS[4] : CARD_DECK_OFFSETS[index],
         !dragStarted && 'transition-transform duration-200 ease-in-out',
         dragStarted &&

--- a/src/features/task/sort/ui/sorting-task-card.tsx
+++ b/src/features/task/sort/ui/sorting-task-card.tsx
@@ -1,6 +1,8 @@
 import { useDraggable } from '@dnd-kit/core'
+import { useEffect, useState } from 'react'
 
 import { TaskCard } from '@/entities/task/ui/task-card'
+import { CARD_DECK_OFFSETS } from '@/features/task/sort/ui/consts'
 import { cn } from '@/shared/lib/utils'
 
 interface SortingTaskCardProps {
@@ -10,6 +12,7 @@ interface SortingTaskCardProps {
   className?: string
 }
 
+// TODO: 책임 분리
 export const SortingTaskCard = ({
   id,
   content,
@@ -22,16 +25,30 @@ export const SortingTaskCard = ({
       disabled: index !== 0,
     })
 
-  const offsets = [
-    'translate-y-[-50%] z-50',
-    'translate-y-[calc(-50%-5px)] z-40',
-    'translate-y-[calc(-50%-10px)] z-30',
-    'translate-y-[calc(-50%-15px)] z-20',
-    'translate-y-[calc(-50%-20px)] z-10',
-  ]
+  const [dragStarted, setDragStarted] = useState(false)
+  const [finalTransform, setFinalTransform] = useState<{
+    x: number
+    y: number
+  } | null>(null)
 
-  const style = transform
-    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+  useEffect(() => {
+    if (!dragStarted && index === 0 && isDragging) {
+      setDragStarted(true)
+    }
+  }, [isDragging, index])
+
+  useEffect(() => {
+    if (transform) {
+      setFinalTransform({ x: transform.x, y: transform.y })
+    }
+  }, [transform?.x, transform?.y])
+
+  const style = finalTransform
+    ? {
+        transform: `translate3d(${finalTransform.x}px, ${finalTransform.y}px, 0) scale(${
+          dragStarted && !isDragging ? 0 : 1
+        })`,
+      }
     : undefined
 
   return (
@@ -42,9 +59,12 @@ export const SortingTaskCard = ({
       {...listeners}
       {...attributes}
       className={cn(
-        'w-64 text-center font-semibold',
-        !isDragging && 'transition-transform duration-200 ease-in-out',
-        index > 4 ? offsets[4] : offsets[index],
+        'w-64 text-center font-semibold ',
+        index > 4 ? CARD_DECK_OFFSETS[4] : CARD_DECK_OFFSETS[index],
+        !dragStarted && 'transition-transform duration-200 ease-in-out',
+        dragStarted &&
+          !isDragging &&
+          'transition-transform duration-100 ease-in-out',
         className,
       )}
     >

--- a/src/features/task/sort/ui/sorting-task-card.tsx
+++ b/src/features/task/sort/ui/sorting-task-card.tsx
@@ -1,0 +1,54 @@
+import { useDraggable } from '@dnd-kit/core'
+
+import { TaskCard } from '@/entities/task/ui/task-card'
+import { cn } from '@/shared/lib/utils'
+
+interface SortingTaskCardProps {
+  id: string
+  content: string
+  index: number
+  className?: string
+}
+
+export const SortingTaskCard = ({
+  id,
+  content,
+  index,
+  className,
+}: SortingTaskCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id,
+      disabled: index !== 0,
+    })
+
+  const offsets = [
+    'translate-y-[-50%] z-50',
+    'translate-y-[calc(-50%-5px)] z-40',
+    'translate-y-[calc(-50%-10px)] z-30',
+    'translate-y-[calc(-50%-15px)] z-20',
+    'translate-y-[calc(-50%-20px)] z-10',
+  ]
+
+  const style = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+    : undefined
+
+  return (
+    <div
+      data-id={id}
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className={cn(
+        'w-64 text-center',
+        !isDragging && 'transition-transform duration-200 ease-in-out',
+        index > 4 ? offsets[4] : offsets[index],
+        className,
+      )}
+    >
+      <TaskCard id={id} content={content} />
+    </div>
+  )
+}

--- a/src/shared/ui/bottom-navigation.tsx
+++ b/src/shared/ui/bottom-navigation.tsx
@@ -20,7 +20,7 @@ export function BottomNavigation({ className }: BottomNavigationProps) {
   }, [pathname])
 
   // 바텀 내비게이션이 없는 페이지
-  if (pathname === '/sorting') {
+  if (pathname === '/sorting' || pathname === '/sorting/additional') {
     return null
   }
 

--- a/src/widgets/sorting-board/ui/sorting-board.tsx
+++ b/src/widgets/sorting-board/ui/sorting-board.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useUnsortedTasks } from '@/entities/task/model/selector'
+import { TaskStatus } from '@/entities/task/model/types'
+import { DropZone } from '@/features/task/sort/ui/drop-zone'
+import { SortingTaskCard } from '@/features/task/sort/ui/sorting-task-card'
+
+export function SortingBoard() {
+  const unsortedTasks = useUnsortedTasks()
+
+  // TODO: 끝나면 토스트 or 완료 모달 띄우고 페이지 넘어가기
+  if (unsortedTasks.length === 0) {
+    window.location.href = '/'
+    return (
+      <div className="h-100 bg-primary border-black overflow-x-hidden">
+        완료 구리!
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="border-black grid h-full w-full grid-cols-2 grid-rows-2">
+        <DropZone status={TaskStatus.UrgentImportant} />
+        <DropZone status={TaskStatus.UrgentNotImportant} />
+        <DropZone status={TaskStatus.NotUrgentImportant} />
+        <DropZone status={TaskStatus.NotUrgentNotImportant} />
+      </div>
+      <div className="absolute top-1/2 left-1/2 w-fit h-fit -translate-x-1/2 -translate-y-1/2">
+        {unsortedTasks.map((task, index) => (
+          <SortingTaskCard
+            key={task.id}
+            id={task.id}
+            content={task.content}
+            index={index}
+            // className="absolute -translate-x-1/2 -translate-y-1/2"
+            className="absolute -translate-x-1/2"
+          />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/widgets/sorting-board/ui/sorting-board.tsx
+++ b/src/widgets/sorting-board/ui/sorting-board.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+
+import { useTaskStore } from '@/entities/task/model/slice'
 import { Task, TaskStatus } from '@/entities/task/model/types'
 import { DropZone } from '@/features/task/sort/ui/drop-zone'
 import { SortingTaskCard } from '@/features/task/sort/ui/sorting-task-card'
@@ -9,12 +13,26 @@ interface SortingBoardProps {
 }
 
 export function SortingBoard({ tasks }: SortingBoardProps) {
-  // TODO: 끝나면 토스트 or 완료 모달 띄우고 페이지 넘어가기
-  if (tasks.length === 0) {
-    window.location.href = '/'
+  const router = useRouter()
+  const setSortingStatus = useTaskStore((state) => state.setSortingStatus)
+  const hasLoaded = useRef(false)
+
+  useEffect(() => {
+    if (!hasLoaded.current) {
+      hasLoaded.current = true
+      return
+    }
+
+    if (tasks.length === 0) {
+      setSortingStatus('SORTED')
+      router.push('/unsorted')
+    }
+  }, [tasks.length, router, setSortingStatus])
+
+  if (tasks.length === 0 && hasLoaded.current) {
     return (
-      <div className="h-100 bg-primary border-black overflow-x-hidden">
-        완료 구리!
+      <div className="h-full flex justify-center items-center">
+        <p className="text-lg font-semibold">분류가 완료되었어요!</p>
       </div>
     )
   }

--- a/src/widgets/sorting-board/ui/sorting-board.tsx
+++ b/src/widgets/sorting-board/ui/sorting-board.tsx
@@ -26,18 +26,15 @@ export function SortingBoard() {
         <DropZone status={TaskStatus.NotUrgentImportant} />
         <DropZone status={TaskStatus.NotUrgentNotImportant} />
       </div>
-      <div className="absolute top-1/2 left-1/2 w-fit h-fit -translate-x-1/2 -translate-y-1/2">
-        {unsortedTasks.map((task, index) => (
-          <SortingTaskCard
-            key={task.id}
-            id={task.id}
-            content={task.content}
-            index={index}
-            // className="absolute -translate-x-1/2 -translate-y-1/2"
-            className="absolute -translate-x-1/2"
-          />
-        ))}
-      </div>
+      {unsortedTasks.map((task, index) => (
+        <SortingTaskCard
+          key={task.id}
+          id={task.id}
+          content={task.content}
+          index={index}
+          className="absolute top-1/2 left-1/2 -translate-x-1/2"
+        />
+      ))}
     </>
   )
 }

--- a/src/widgets/sorting-board/ui/sorting-board.tsx
+++ b/src/widgets/sorting-board/ui/sorting-board.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { useUnsortedTasks } from '@/entities/task/model/selector'
-import { TaskStatus } from '@/entities/task/model/types'
+import { Task, TaskStatus } from '@/entities/task/model/types'
 import { DropZone } from '@/features/task/sort/ui/drop-zone'
 import { SortingTaskCard } from '@/features/task/sort/ui/sorting-task-card'
 
-export function SortingBoard() {
-  const unsortedTasks = useUnsortedTasks()
+interface SortingBoardProps {
+  tasks: Task[]
+}
 
+export function SortingBoard({ tasks }: SortingBoardProps) {
   // TODO: 끝나면 토스트 or 완료 모달 띄우고 페이지 넘어가기
-  if (unsortedTasks.length === 0) {
+  if (tasks.length === 0) {
     window.location.href = '/'
     return (
       <div className="h-100 bg-primary border-black overflow-x-hidden">
@@ -26,7 +27,7 @@ export function SortingBoard() {
         <DropZone status={TaskStatus.NotUrgentImportant} />
         <DropZone status={TaskStatus.NotUrgentNotImportant} />
       </div>
-      {unsortedTasks.map((task, index) => (
+      {tasks.map((task, index) => (
         <SortingTaskCard
           key={task.id}
           id={task.id}

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,37 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/modifiers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz#96a0280c77b10c716ef79d9792ce7ad04370771d"
+  integrity sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emnapi/core@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.3.tgz#9ac52d2d5aea958f67e52c40a065f51de59b77d6"


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #27

## ☑️ 작업한 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- `SortingProvider`,  `SortingTaskCard`, `DropZone`, `SortingBoard` 구현
- 페이지 /sorting, /sorting/additional로 분리 (가져오는 task 데이터가 달라서 분리)
- Postponed 상태 추가 (분류 중 갑작스러운 중단 시 이전 분류 작업을 이어가기 위해 별도 타입 추가, Postponed이 없으면 task의 index를 통해 중단점을 관리해야 해서 복잡해짐)
- useAddTask로 확장 (sortingStatus 상태 변경을 위해 addTask와 통합)

## ⭐ 추가 개선사항

<!-- 추가로 작업할 내용을 간단하게 설명해주세요 -->
- DragOverlay 적용
- 드래그 중 다시 카드덱으로 드롭하면 선택 보류하는 기능 (카드덱 주변으로 드래그 시 dropzone 감지 안되게 + 카드 다시 원위치로 이동)
- Dragend 애니메이션 자연스럽게 수정
- 분류 완료 UI 인터렉티브하게 수정
- 복잡한 컴포넌트 리팩터링
- Header 파일로 분리
- 지금까지 한 애니메이션 motion으로 대체 가능하면 변경할지 결정 (현재 애니메이션 너무 단조롭고 별로)

## 👀 참고 사항
- `SortingProvider`를 쓰기 때문에 context를 따로 만들지 않음
- 드래그 존은 헤더를 제외한 전체로 설정
- dnd-kit는 터치는 추가로 설정하지 않으면 작동 안 함


