### PR TITLE
✨ Sorting 페이지 미루기, 취소하기 버튼 추가

### DIFF
--- a/src/app/sorting/additional/page.tsx
+++ b/src/app/sorting/additional/page.tsx
@@ -1,9 +1,21 @@
 'use client'
 
-import { useUnsortedTodayTasks } from '@/entities/task/model/selector'
+import { useRef } from 'react'
+
+import {
+  getUnsortedTodayTasks,
+  useUnsortedTodayTasks,
+} from '@/entities/task/model/selector'
 import { SortingBoard } from '@/widgets/sorting-board/ui/sorting-board'
 
 export default function AdditionalPage() {
   const todayUnassignedTasks = useUnsortedTodayTasks()
-  return <SortingBoard tasks={todayUnassignedTasks} />
+  const originalTodayTasks = useRef(getUnsortedTodayTasks())
+
+  return (
+    <SortingBoard
+      tasks={todayUnassignedTasks}
+      originalTasks={originalTodayTasks.current}
+    />
+  )
 }

--- a/src/app/sorting/page.tsx
+++ b/src/app/sorting/page.tsx
@@ -1,9 +1,16 @@
 'use client'
+import { useRef } from 'react'
 
-import { useUnsortedTasks } from '@/entities/task/model/selector'
+import {
+  getUnsortedTasks,
+  useUnsortedTasks,
+} from '@/entities/task/model/selector'
 import { SortingBoard } from '@/widgets/sorting-board/ui/sorting-board'
 
 export default function SortingPage() {
   const unsortedTasks = useUnsortedTasks()
-  return <SortingBoard tasks={unsortedTasks} />
+  const originalTasks = useRef(getUnsortedTasks())
+  return (
+    <SortingBoard tasks={unsortedTasks} originalTasks={originalTasks.current} />
+  )
 }

--- a/src/app/unsorted/page.tsx
+++ b/src/app/unsorted/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useUnsortedTasks } from '@/entities/task/model/selector'
+import { useUnsortedOrPostponeTasks } from '@/entities/task/model/selector'
 import { AddTaskContainer } from '@/features/task/add/ui/add-task-container'
 import { useUnsorted } from '@/features/task/organize/model/context'
 import { cn } from '@/shared/lib/utils'
@@ -9,7 +9,7 @@ import { TaskList } from '@/widgets/unsorted-list/ui/task-list'
 
 export default function UnsortedPage() {
   const { isEditMode } = useUnsorted()
-  const unsortedTasks = useUnsortedTasks()
+  const unsortedTasks = useUnsortedOrPostponeTasks()
 
   return (
     <div

--- a/src/entities/task/model/selector.ts
+++ b/src/entities/task/model/selector.ts
@@ -13,18 +13,21 @@ export const isTodayTask = ([_, task]: [string, Task]) => task.isToday
  * (컴포넌트 외부에서 직접 상태 접근용)
  * @returns {TaskList} 분류되지 않은 태스크 목록
  */
-export const getUnsortedTasks = (): TaskList =>
-  [...useTaskStore.getState().tasks.entries()].filter(isUnsorted)
-
+export const getUnsortedTasks = (): TaskList => {
+  const tasks = useTaskStore.getState().tasks
+  return Object.entries(tasks).filter(isUnsorted)
+}
 /**
  * 현재 상태에서 오늘 날짜이고 분류되지 않은 태스크 배열을 반환합니다.
  * (컴포넌트 외부에서 직접 상태 접근용)
  * @returns {TaskList} 오늘 할 일 중 분류되지 않은 태스크 목록
  */
-export const getUnsortedTodayTasks = (): TaskList =>
-  [...useTaskStore.getState().tasks.entries()].filter(
+export const getUnsortedTodayTasks = (): TaskList => {
+  const tasks = useTaskStore.getState().tasks
+  return Object.entries(tasks).filter(
     (task) => isUnsorted(task) && isTodayTask(task),
   )
+}
 
 /**
  * 분류되지 않은 태스크 목록을 구독 및 반환
@@ -35,7 +38,7 @@ export const useUnsortedTasks = (): TaskList => {
   const tasks = useTaskStore((state) => state.tasks)
 
   return useMemo(() => {
-    return [...tasks.entries()].filter(isUnsorted)
+    return Object.entries(tasks).filter(isUnsorted)
   }, [tasks])
 }
 
@@ -48,7 +51,7 @@ export const useUnsortedTodayTasks = (): TaskList => {
   const tasks = useTaskStore((state) => state.tasks)
 
   return useMemo(() => {
-    return [...tasks.entries()].filter(
+    return Object.entries(tasks).filter(
       (task) => isUnsorted(task) && isTodayTask(task),
     )
   }, [tasks])
@@ -63,8 +66,8 @@ export const useTodaySortedTasks = (status: TaskStatus): TaskList => {
   const tasks = useTaskStore((state) => state.tasks)
 
   return useMemo(() => {
-    return [...tasks.entries()].filter(
-      ([_, task]: [string, Task]) =>
+    return Object.entries(tasks).filter(
+      ([_, task]) =>
         task.status === status &&
         task.isToday &&
         task.status !== TaskStatus.Unassigned,

--- a/src/entities/task/model/selector.ts
+++ b/src/entities/task/model/selector.ts
@@ -1,67 +1,70 @@
 import { useMemo } from 'react'
 
 import { useTaskStore } from './slice'
-import { Task, TaskStatus } from './types'
+import { Task, TaskList, TaskStatus } from './types'
 
-export const isCompleted = (task: Task) => !!task.completedAt
-export const isUnsorted = (task: Task) => task.status === TaskStatus.Unassigned
-export const isTodayTask = (task: Task) => task.isToday
+export const isCompleted = ([_, task]: [string, Task]) => !!task.completedAt
+export const isUnsorted = ([_, task]: [string, Task]) =>
+  task.status === TaskStatus.Unassigned
+export const isTodayTask = ([_, task]: [string, Task]) => task.isToday
 
 /**
  * 현재 상태에서 분류되지 않은 모든 태스크 배열을 반환합니다.
  * (컴포넌트 외부에서 직접 상태 접근용)
- * @returns {Task[]} 분류되지 않은 태스크 목록
+ * @returns {TaskList} 분류되지 않은 태스크 목록
  */
-export const getUnsortedTasks = (): Task[] =>
-  useTaskStore.getState().tasks.filter(isUnsorted)
+export const getUnsortedTasks = (): TaskList =>
+  [...useTaskStore.getState().tasks.entries()].filter(isUnsorted)
 
 /**
  * 현재 상태에서 오늘 날짜이고 분류되지 않은 태스크 배열을 반환합니다.
  * (컴포넌트 외부에서 직접 상태 접근용)
- * @returns {Task[]} 오늘 할 일 중 분류되지 않은 태스크 목록
+ * @returns {TaskList} 오늘 할 일 중 분류되지 않은 태스크 목록
  */
-export const getUnsortedTodayTasks = (): Task[] =>
-  useTaskStore
-    .getState()
-    .tasks.filter((task) => isUnsorted(task) && isTodayTask(task))
+export const getUnsortedTodayTasks = (): TaskList =>
+  [...useTaskStore.getState().tasks.entries()].filter(
+    (task) => isUnsorted(task) && isTodayTask(task),
+  )
 
 /**
  * 분류되지 않은 태스크 목록을 구독 및 반환
  * (컴포넌트 내 훅)
- * @returns {Task[]} 분류되지 않은 태스크 목록
+ * @returns {TaskList} 분류되지 않은 태스크 목록
  */
-export const useUnsortedTasks = (): Task[] => {
+export const useUnsortedTasks = (): TaskList => {
   const tasks = useTaskStore((state) => state.tasks)
 
   return useMemo(() => {
-    return tasks.filter(isUnsorted)
+    return [...tasks.entries()].filter(isUnsorted)
   }, [tasks])
 }
 
 /**
  * 오늘 날짜이고 분류되지 않은 태스크 목록을 구독 및 반환
  * (컴포넌트 내 훅)
- * @returns {Task[]} 오늘 할 일 중 분류되지 않은 태스크 목록
+ * @returns {TaskList} 오늘 할 일 중 분류되지 않은 태스크 목록
  */
-export const useUnsortedTodayTasks = (): Task[] => {
+export const useUnsortedTodayTasks = (): TaskList => {
   const tasks = useTaskStore((state) => state.tasks)
 
   return useMemo(() => {
-    return tasks.filter((task) => isUnsorted(task) && isTodayTask(task))
+    return [...tasks.entries()].filter(
+      (task) => isUnsorted(task) && isTodayTask(task),
+    )
   }, [tasks])
 }
 
 /**
  * 오늘 날짜이며 특정 상태에 해당하는 분류된 태스크 목록을 구독 및 반환
  * @param {TaskStatus} status - 조회할 태스크 상태
- * @returns {Task[]} 오늘 할 일 중 해당 상태에 속하는 태스크 목록
+ * @returns {TaskList} 오늘 할 일 중 해당 상태에 속하는 태스크 목록
  */
-export const useTodaySortedTasks = (status: TaskStatus): Task[] => {
+export const useTodaySortedTasks = (status: TaskStatus): TaskList => {
   const tasks = useTaskStore((state) => state.tasks)
 
   return useMemo(() => {
-    return tasks.filter(
-      (task) =>
+    return [...tasks.entries()].filter(
+      ([_, task]: [string, Task]) =>
         task.status === status &&
         task.isToday &&
         task.status !== TaskStatus.Unassigned,

--- a/src/entities/task/model/selector.ts
+++ b/src/entities/task/model/selector.ts
@@ -5,7 +5,7 @@ import { Task, TaskList, TaskStatus } from './types'
 
 export const isCompleted = ([_, task]: [string, Task]) => !!task.completedAt
 export const isUnsorted = ([_, task]: [string, Task]) =>
-  task.status === TaskStatus.Unassigned
+  task.status === TaskStatus.Unassigned || task.status === TaskStatus.Postponed
 export const isTodayTask = ([_, task]: [string, Task]) => task.isToday
 
 /**
@@ -67,10 +67,7 @@ export const useTodaySortedTasks = (status: TaskStatus): TaskList => {
 
   return useMemo(() => {
     return Object.entries(tasks).filter(
-      ([_, task]) =>
-        task.status === status &&
-        task.isToday &&
-        task.status !== TaskStatus.Unassigned,
+      ([_, task]) => task.status === status && task.isToday,
     )
   }, [tasks, status])
 }

--- a/src/entities/task/model/selector.ts
+++ b/src/entities/task/model/selector.ts
@@ -5,7 +5,9 @@ import { Task, TaskList, TaskStatus } from './types'
 
 export const isCompleted = ([_, task]: [string, Task]) => !!task.completedAt
 export const isUnsorted = ([_, task]: [string, Task]) =>
-  task.status === TaskStatus.Unassigned || task.status === TaskStatus.Postponed
+  task.status === TaskStatus.Unassigned
+export const isPostponed = ([_, task]: [string, Task]) =>
+  task.status === TaskStatus.Postponed
 export const isTodayTask = ([_, task]: [string, Task]) => task.isToday
 
 /**
@@ -17,6 +19,7 @@ export const getUnsortedTasks = (): TaskList => {
   const tasks = useTaskStore.getState().tasks
   return Object.entries(tasks).filter(isUnsorted)
 }
+
 /**
  * 현재 상태에서 오늘 날짜이고 분류되지 않은 태스크 배열을 반환합니다.
  * (컴포넌트 외부에서 직접 상태 접근용)
@@ -39,6 +42,21 @@ export const useUnsortedTasks = (): TaskList => {
 
   return useMemo(() => {
     return Object.entries(tasks).filter(isUnsorted)
+  }, [tasks])
+}
+
+/**
+ * 분류되지 않은 태스크 목록을 구독 및 반환
+ * (unsorted 페이지에서 사용)
+ * @returns {TaskList} 분류되지 않은 태스크 목록
+ */
+export const useUnsortedOrPostponeTasks = (): TaskList => {
+  const tasks = useTaskStore((state) => state.tasks)
+
+  return useMemo(() => {
+    return Object.entries(tasks).filter(
+      (task) => isUnsorted(task) || isPostponed(task),
+    )
   }, [tasks])
 }
 

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -52,6 +52,7 @@ interface TaskActions {
   deleteTask: (taskId: string) => void
   deleteAllTask: () => void
   sortTask: (taskId: string, status: TaskStatus) => void
+  undoTask: (taskId: string) => void
   postponeTask: (taskId: string) => void
   completeTask: (taskId: string) => void
   uncompleteTask: (taskId: string) => void

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -13,7 +13,7 @@ export type MatrixTaskStatus = Exclude<
 >
 
 // TaskMap: 각 Task의 id(UUID)를 key로 하여 Task 객체를 저장하는 Map
-export type TaskMap = Map<string, Task>
+export type TaskMap = Record<string, Task>
 
 // TaskList: [id, Task] 쌍의 배열로, Map의 entries()에서 사용
 export type TaskList = [string, Task][]

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -12,11 +12,16 @@ export type MatrixTaskStatus = Exclude<
   TaskStatus.Unassigned | TaskStatus.Postponed
 >
 
+// TaskMap: 각 Task의 id(UUID)를 key로 하여 Task 객체를 저장하는 Map
+export type TaskMap = Map<string, Task>
+
+// TaskList: [id, Task] 쌍의 배열로, Map의 entries()에서 사용
+export type TaskList = [string, Task][]
+
 export interface Task {
-  // UUID
-  id: string
   // 할 일 내용
   content: string
+  // 분류 상테
   status: TaskStatus
   // "오늘 바로 해야하는 일" 체크시 true
   isToday: boolean
@@ -36,7 +41,7 @@ export type SortingStatus =
   | 'ADDITIONAL_SORTING' // 추가 분류 중
 
 interface TaskState {
-  tasks: Task[]
+  tasks: TaskMap
   sortingStatus: SortingStatus | undefined
   hydrated: boolean
 }

--- a/src/entities/task/model/types.ts
+++ b/src/entities/task/model/types.ts
@@ -21,7 +21,7 @@ export type TaskList = [string, Task][]
 export interface Task {
   // 할 일 내용
   content: string
-  // 분류 상테
+  // 분류 상태
   status: TaskStatus
   // "오늘 바로 해야하는 일" 체크시 true
   isToday: boolean

--- a/src/entities/task/ui/task-check-items.tsx
+++ b/src/entities/task/ui/task-check-items.tsx
@@ -17,17 +17,17 @@ export const TaskCheckItems = ({ status }: TaskCheckItemsProps) => {
 
   return (
     <div className={cn('w-full flex flex-col gap-2', tasks.length && 'pb-4')}>
-      {tasks.map((task) => (
+      {tasks.map(([id, task]) => (
         <CheckboxWithLabel
-          key={task.id}
-          id={task.id}
+          key={id}
+          id={id}
           label={task.content}
           checked={!!task.completedAt}
           onCheckedChange={() => {
             if (task.completedAt) {
-              uncompleteTask(task.id)
+              uncompleteTask(id)
             } else {
-              completeTask(task.id)
+              completeTask(id)
             }
           }}
           strikethrough

--- a/src/features/task/sort/ui/postpone-button.tsx
+++ b/src/features/task/sort/ui/postpone-button.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { ClockArrowDown } from 'lucide-react'
+
+import { useTaskStore } from '@/entities/task/model/slice'
+import { cn } from '@/shared/lib/utils'
+import { Button } from '@/shared/ui/button'
+
+interface PostponeButtonProps {
+  id: string
+  className?: string
+}
+
+export function PostponeButton({ id, className }: PostponeButtonProps) {
+  const postponeTask = useTaskStore((state) => state.postponeTask)
+
+  const handleClick = () => {
+    postponeTask(id)
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="muted"
+      className={cn('hover:text-foreground/70', className)}
+      onClick={handleClick}
+    >
+      <ClockArrowDown />
+      Postpone Task
+    </Button>
+  )
+}

--- a/src/features/task/sort/ui/sorting-task-card.tsx
+++ b/src/features/task/sort/ui/sorting-task-card.tsx
@@ -1,5 +1,5 @@
 import { useDraggable } from '@dnd-kit/core'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { TaskCard } from '@/entities/task/ui/task-card'
 import { CARD_DECK_OFFSETS } from '@/features/task/sort/ui/consts'
@@ -26,10 +26,7 @@ export const SortingTaskCard = ({
     })
 
   const [dragStarted, setDragStarted] = useState(false)
-  const [finalTransform, setFinalTransform] = useState<{
-    x: number
-    y: number
-  } | null>(null)
+  const finalTransformRef = useRef<{ x: number; y: number } | null>(null)
 
   useEffect(() => {
     if (!dragStarted && index === 0 && isDragging) {
@@ -39,13 +36,13 @@ export const SortingTaskCard = ({
 
   useEffect(() => {
     if (transform) {
-      setFinalTransform({ x: transform.x, y: transform.y })
+      finalTransformRef.current = { x: transform.x, y: transform.y }
     }
   }, [transform?.x, transform?.y])
 
-  const style = finalTransform
+  const style = finalTransformRef.current
     ? {
-        transform: `translate3d(${finalTransform.x}px, ${finalTransform.y}px, 0) scale(${
+        transform: `translate3d(${finalTransformRef.current.x}px, ${finalTransformRef.current.y}px, 0) scale(${
           dragStarted && !isDragging ? 0 : 1
         })`,
       }

--- a/src/features/task/sort/ui/undo-button.tsx
+++ b/src/features/task/sort/ui/undo-button.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { Undo2 } from 'lucide-react'
+
+import { useTaskStore } from '@/entities/task/model/slice'
+import { TaskList } from '@/entities/task/model/types'
+import { cn } from '@/shared/lib/utils'
+import { Button } from '@/shared/ui/button'
+
+interface UndoButtonProps {
+  id: string
+  originalTasks: TaskList
+  className?: string
+}
+
+export function UndoButton({ originalTasks, id, className }: UndoButtonProps) {
+  const undoTask = useTaskStore((state) => state.undoTask)
+
+  const handleClick = () => {
+    const targetTask = originalTasks.find(
+      (_, index) => originalTasks[index + 1][0] === id,
+    )
+    if (targetTask) {
+      undoTask(targetTask[0])
+    }
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="muted"
+      className={cn(
+        'opacity-90 hover:opacity-100 hover:text-foreground/70',
+        className,
+      )}
+      onClick={handleClick}
+    >
+      <Undo2 />
+      Undo Task
+    </Button>
+  )
+}

--- a/src/features/task/sort/ui/undo-button.tsx
+++ b/src/features/task/sort/ui/undo-button.tsx
@@ -16,6 +16,9 @@ export function UndoButton({ originalTasks, id, className }: UndoButtonProps) {
   const undoTask = useTaskStore((state) => state.undoTask)
 
   const handleClick = () => {
+    if (originalTasks[0][0] === id) {
+      return
+    }
     const targetTask = originalTasks.find(
       (_, index) => originalTasks[index + 1][0] === id,
     )

--- a/src/stories/AddTaskForm.stories.tsx
+++ b/src/stories/AddTaskForm.stories.tsx
@@ -6,7 +6,7 @@ import { once } from '@/shared/lib/utils'
 import { Toaster } from '@/shared/ui/sonner'
 
 const initializeTaskStoreOnce = once(() => {
-  useTaskStore.setState({ tasks: [] })
+  useTaskStore.setState({ tasks: {} })
 })
 
 const meta: Meta<typeof AddTaskForm> = {

--- a/src/stories/EditTaskContainer.stories.tsx
+++ b/src/stories/EditTaskContainer.stories.tsx
@@ -11,9 +11,8 @@ import { Toaster } from '@/shared/ui/sonner'
 const initializeTaskStoreOnce = once(() => {
   const now = getCurrentDate()
   useTaskStore.setState({
-    tasks: [
-      {
-        id: '1',
+    tasks: {
+      '1': {
         content: 'Test Task',
         status: TaskStatus.Unassigned,
         completedAt: now,
@@ -21,7 +20,7 @@ const initializeTaskStoreOnce = once(() => {
         postponedCount: 0,
         updatedAt: now,
       },
-    ],
+    },
   })
 })
 

--- a/src/stories/EditTaskForm.stories.tsx
+++ b/src/stories/EditTaskForm.stories.tsx
@@ -10,9 +10,8 @@ import { Toaster } from '@/shared/ui/sonner'
 const initializeTaskStoreOnce = once(() => {
   const now = getCurrentDate()
   useTaskStore.setState({
-    tasks: [
-      {
-        id: '1',
+    tasks: {
+      '1': {
         content: 'Test Task',
         status: TaskStatus.Unassigned,
         completedAt: now,
@@ -20,7 +19,7 @@ const initializeTaskStoreOnce = once(() => {
         postponedCount: 0,
         updatedAt: now,
       },
-    ],
+    },
   })
 })
 

--- a/src/stories/PostponeButton.stories.tsx
+++ b/src/stories/PostponeButton.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+
+import { PostponeButton } from '@/features/task/sort/ui/postpone-button'
+
+const meta = {
+  title: 'Features/Task/Sort/PostponeButton',
+  component: PostponeButton,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PostponeButton>
+
+export default meta
+type Story = StoryObj<typeof PostponeButton>
+
+export const Default: Story = {
+  args: {
+    id: '1',
+  },
+}

--- a/src/stories/TaskCheckItems.stories.tsx
+++ b/src/stories/TaskCheckItems.stories.tsx
@@ -15,17 +15,15 @@ const meta: Meta<typeof TaskCheckItems> = {
     (Story) => {
       const now = getCurrentDate()
       useTaskStore.setState({
-        tasks: [
-          {
-            id: '1',
+        tasks: {
+          '1': {
             content: 'Task 1',
             status: TaskStatus.UrgentImportant,
             isToday: true,
             postponedCount: 0,
             updatedAt: now,
           },
-          {
-            id: '2',
+          '2': {
             content: 'Task 2',
             status: TaskStatus.UrgentImportant,
             completedAt: now,
@@ -33,8 +31,7 @@ const meta: Meta<typeof TaskCheckItems> = {
             postponedCount: 0,
             updatedAt: now,
           },
-          {
-            id: '3',
+          '3': {
             content: 'Task 3',
             status: TaskStatus.UrgentImportant,
             completedAt: now,
@@ -42,7 +39,7 @@ const meta: Meta<typeof TaskCheckItems> = {
             postponedCount: 0,
             updatedAt: now,
           },
-        ],
+        },
       })
       return <Story />
     },

--- a/src/stories/TaskEditableList.stories.tsx
+++ b/src/stories/TaskEditableList.stories.tsx
@@ -11,24 +11,23 @@ import { TaskEditableList } from '@/widgets/unsorted-list/ui/task-editable-list'
 const initializeTaskStoreOnce = once(() => {
   const now = getCurrentDate()
   useTaskStore.setState({
-    tasks: [
-      {
-        id: '1',
-        content: '청소하기',
+    tasks: {
+      '1': {
+        content: 'Test Task',
         status: TaskStatus.Unassigned,
+        completedAt: now,
         isToday: true,
         postponedCount: 0,
         updatedAt: now,
       },
-      {
-        id: '2',
+      '2': {
         content: '공부하기',
         status: TaskStatus.Unassigned,
         isToday: false,
         postponedCount: 0,
         updatedAt: now,
       },
-    ],
+    },
   })
 })
 

--- a/src/stories/TaskList.stories.tsx
+++ b/src/stories/TaskList.stories.tsx
@@ -11,24 +11,23 @@ import { TaskList } from '@/widgets/unsorted-list/ui/task-list'
 const initializeTaskStoreOnce = once(() => {
   const now = getCurrentDate()
   useTaskStore.setState({
-    tasks: [
-      {
-        id: '1',
-        content: '청소하기',
+    tasks: {
+      '1': {
+        content: 'Test Task',
         status: TaskStatus.Unassigned,
+        completedAt: now,
         isToday: true,
         postponedCount: 0,
         updatedAt: now,
       },
-      {
-        id: '2',
+      '2': {
         content: '공부하기',
         status: TaskStatus.Unassigned,
         isToday: false,
         postponedCount: 0,
         updatedAt: now,
       },
-    ],
+    },
   })
 })
 

--- a/src/stories/UndoButton.stories.tsx
+++ b/src/stories/UndoButton.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+
+import { UndoButton } from '@/features/task/sort/ui/undo-button'
+
+const meta = {
+  title: 'Features/Task/Sort/UndoButton',
+  component: UndoButton,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof UndoButton>
+
+export default meta
+type Story = StoryObj<typeof UndoButton>
+
+export const Default: Story = {
+  args: {
+    id: '1',
+  },
+}

--- a/src/widgets/sorting-board/ui/sorting-board.tsx
+++ b/src/widgets/sorting-board/ui/sorting-board.tsx
@@ -6,13 +6,16 @@ import { useEffect } from 'react'
 import { useTaskStore } from '@/entities/task/model/slice'
 import { TaskList, TaskStatus } from '@/entities/task/model/types'
 import { DropZone } from '@/features/task/sort/ui/drop-zone'
+import { PostponeButton } from '@/features/task/sort/ui/postpone-button'
 import { SortingTaskCard } from '@/features/task/sort/ui/sorting-task-card'
+import { UndoButton } from '@/features/task/sort/ui/undo-button'
 
 interface SortingBoardProps {
   tasks: TaskList
+  originalTasks: TaskList
 }
 
-export function SortingBoard({ tasks }: SortingBoardProps) {
+export function SortingBoard({ tasks, originalTasks }: SortingBoardProps) {
   const router = useRouter()
   const hydrated = useTaskStore((state) => state.hydrated)
 
@@ -22,7 +25,6 @@ export function SortingBoard({ tasks }: SortingBoardProps) {
     if (!hydrated) {
       return
     }
-
     if (tasks.length === 0) {
       setSortingStatus('SORTED')
       router.push('/unsorted')
@@ -54,6 +56,19 @@ export function SortingBoard({ tasks }: SortingBoardProps) {
           className="absolute top-1/2 left-1/2 -translate-x-1/2"
         />
       ))}
+      {tasks.length > 0 && (
+        <>
+          <PostponeButton
+            id={tasks[0][0]}
+            className="absolute top-4/7 left-1/2 -translate-x-1/2"
+          />
+          <UndoButton
+            id={tasks[0][0]}
+            originalTasks={originalTasks}
+            className="absolute top-4 left-1/2 -translate-x-1/2"
+          />
+        </>
+      )}
     </>
   )
 }

--- a/src/widgets/sorting-board/ui/sorting-board.tsx
+++ b/src/widgets/sorting-board/ui/sorting-board.tsx
@@ -4,12 +4,12 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 
 import { useTaskStore } from '@/entities/task/model/slice'
-import { Task, TaskStatus } from '@/entities/task/model/types'
+import { TaskList, TaskStatus } from '@/entities/task/model/types'
 import { DropZone } from '@/features/task/sort/ui/drop-zone'
 import { SortingTaskCard } from '@/features/task/sort/ui/sorting-task-card'
 
 interface SortingBoardProps {
-  tasks: Task[]
+  tasks: TaskList
 }
 
 export function SortingBoard({ tasks }: SortingBoardProps) {
@@ -45,10 +45,10 @@ export function SortingBoard({ tasks }: SortingBoardProps) {
         <DropZone status={TaskStatus.UrgentNotImportant} />
         <DropZone status={TaskStatus.NotUrgentNotImportant} />
       </div>
-      {tasks.map((task, index) => (
+      {tasks.map(([id, task], index) => (
         <SortingTaskCard
-          key={task.id}
-          id={task.id}
+          key={id}
+          id={id}
           content={task.content}
           index={index}
           className="absolute top-1/2 left-1/2 -translate-x-1/2"

--- a/src/widgets/unsorted-list/ui/task-editable-list.tsx
+++ b/src/widgets/unsorted-list/ui/task-editable-list.tsx
@@ -3,12 +3,12 @@
 import { useState } from 'react'
 
 import { useTaskStore } from '@/entities/task/model/slice'
-import { Task } from '@/entities/task/model/types'
+import { TaskList } from '@/entities/task/model/types'
 import { TaskEditableCard } from '@/entities/task/ui/task-editable-card'
 import { EditTaskContainer } from '@/features/task/organize/ui/edit-task-container'
 
 interface TaskEditableListProps {
-  tasks: Task[]
+  tasks: TaskList
 }
 
 export function TaskEditableList({ tasks }: TaskEditableListProps) {
@@ -17,9 +17,9 @@ export function TaskEditableList({ tasks }: TaskEditableListProps) {
   const deleteTask = useTaskStore((state) => state.deleteTask)
 
   // 편집 모드 열기
-  const openEdit = (task: Task) => {
-    setEditingTaskId(task.id)
-    setEditContent(task.content)
+  const openEdit = (id: string, content: string) => {
+    setEditingTaskId(id)
+    setEditContent(content)
   }
 
   // 편집 모드 닫기
@@ -30,13 +30,13 @@ export function TaskEditableList({ tasks }: TaskEditableListProps) {
   return (
     <>
       <div className="flex flex-col gap-2">
-        {tasks.map((task) => (
+        {tasks.map(([id, task]) => (
           <TaskEditableCard
-            key={task.id}
-            id={task.id}
+            key={id}
+            id={id}
             content={task.content}
-            onEdit={() => openEdit(task)}
-            onDelete={() => deleteTask(task.id)}
+            onEdit={() => openEdit(id, task.content)}
+            onDelete={() => deleteTask(id)}
           />
         ))}
       </div>

--- a/src/widgets/unsorted-list/ui/task-list.tsx
+++ b/src/widgets/unsorted-list/ui/task-list.tsx
@@ -1,17 +1,17 @@
-import { Task } from '@/entities/task/model/types'
+import { TaskList as TypeTaskList } from '@/entities/task/model/types'
 import { TaskCard } from '@/entities/task/ui/task-card'
 
 interface TaskListProps {
-  tasks: Task[]
+  tasks: TypeTaskList
 }
 
 export function TaskList({ tasks }: TaskListProps) {
   return (
     <div className="flex flex-col gap-2">
-      {tasks.map((task: Task) => (
+      {tasks.map(([id, task]) => (
         <TaskCard
-          key={task.id}
-          id={task.id}
+          key={id}
+          id={id}
           content={task.content}
           isToday={task.isToday}
         />


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- #37

## ☑️ 작업한 내용

<!-- 작업한 내용을 간단히 설명해주세요 -->
- `PostponeButton` 구현
  - `Postponed` 타입이 추가되면서 `Unassigned`와 `Postponed` 타입을 모두 고려하여 `selector`를 수정
  - `useUnsortedTasks`(sorting 페이지에서 사용)와 `useUnsortedOrPostponeTasks`(unsorted 페이지에서 사용)로 분리
- `UndoButton` 구현
  - sorting 페이지는 zustand selector로 신선한 `unassignedTasks`만 가져오기 때문에 분류 전 `originalTasks`를 `useRef`의 초기값으로 받아와 `undo` 기능을 구현
- 그동안 Task를 배열로 관리하고 있었으나 뒤로 미루기, undo 기능이 추가되면서 수정 기능이 빈번해졌고 시간복잡도가 O(1)인 Object로 관리하도록 전면 수정 
  - 먼저 Map 도입을 고려했지만 직렬화가 필요한 기능(redux devtool, zustand persist)과 호환이 어렵기 때문에 `object` 채택 
- 또한 sorting 페이지에서 `Maximum update depth exceeded` 에러가 발생했는데 `setFinalTransform`이 원인이라 파악하고 `useRef`로 변경해서 해결 (어차피 dnd에서 드래그 애니메이션을 관리하기 때문에 리렌더링을 일으키는 `useState`를 사용할 필요가 없었음)

## ⭐ 추가 개선사항

<!-- 추가로 작업할 내용을 간단하게 설명해주세요 -->
- `useUnsortedOrPostponeTasks` 리네이밍

## 👀 참고 사항

<!-- 참고 사항을 설명해주세요 -->
- Task를 object로 변경하여 관련 코드들을 다 리팩터링해야했는데 스토리북을 빼먹고 진행함. 다음에는 꼭 확인하기!

